### PR TITLE
Added tomlin subfolder to jpm sources

### DIFF
--- a/project.janet
+++ b/project.janet
@@ -11,4 +11,5 @@
 
 
 (declare-source
-  :source ["src/tomlin.janet"])
+  :source ["src/tomlin.janet"
+           "src/tomlin"])


### PR DESCRIPTION
I added the `src/tomlin` subfolder to the jpm sources, because currently when running `(import tomlin)` there is an error:

```janet
repl:1:> (import tomlin)
error: could not find module ./tomlin/grammar:
    /usr/lib/janet/tomlin/grammar.jimage
    /usr/lib/janet/tomlin/grammar.janet
    /usr/lib/janet/tomlin/grammar/init.janet
    /usr/lib/janet/tomlin/grammar.so
  in require-1 [boot.janet] on line 2895, column 20
  in import* [boot.janet] on line 2934, column 15
  in _thunk [/usr/lib/janet/tomlin.janet] (tailcall) on line 1, column 1
  in dofile [boot.janet] (tailcall) on line 2872, column 7
  in source-loader [boot.janet] on line 2883, column 15
  in require-1 [boot.janet] on line 2903, column 18
  in import* [boot.janet] on line 2934, column 15
  in _thunk [repl] (tailcall) on line 1, column 1
```

After my changes the import works properly:
```janet
repl:1:> (import tomlin)
@{_ @{:value <cycle 0>} tomlin/toml->janet @{:private true} :macro-lints @[]}
```