### PR TITLE
Isolate development dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,3 +14,6 @@ jobs:
     steps:
     - name: "Test project"
       uses: pyrmont/action-janet-test@master
+      with:
+        cmd-deps: "jpm -l run dev-deps"
+        cmd-test: "jpm -l test"

--- a/project.janet
+++ b/project.janet
@@ -5,11 +5,28 @@
   :license "MIT"
   :url "https://github.com/pyrmont/tomlin"
   :repo "git+https://github.com/pyrmont/tomlin"
-  :dependencies ["https://github.com/janet-lang/spork"
-                 "https://github.com/janet-lang/json"
-                 "https://github.com/pyrmont/testament"])
+  :dependencies []
+  :dev-dependencies ["https://github.com/janet-lang/json"
+                     "https://github.com/pyrmont/testament"])
 
+# Library
 
 (declare-source
   :source ["src/tomlin.janet"
            "src/tomlin"])
+
+# Development
+
+(task "dev-deps" []
+  (if-let [deps ((dyn :project) :dependencies)]
+    (each dep deps
+      (bundle-install dep))
+    (do
+      (print "no dependencies found")
+      (flush)))
+  (if-let [deps ((dyn :project) :dev-dependencies)]
+    (each dep deps
+      (bundle-install dep))
+    (do
+      (print "no dev-dependencies found")
+      (flush))))


### PR DESCRIPTION
This PR moves dependencies that are only necessary for development out of the `:deps` tuple and into a `:dev-deps` tuple that can be installed using `jpm run dev-deps`.