### PR TITLE
Fix nested tables within array of tables

### DIFF
--- a/src/tomlin.janet
+++ b/src/tomlin.janet
@@ -25,14 +25,15 @@
 (defn- get-from-table [target ks std-table?]
   (var t target)
   (var i 0)
-  (while (< i (dec (length ks)))
+  (var last-i (dec (length ks)))
+  (while (< i last-i)
     (def k (get ks i))
     (def v (get t k))
     (case (type v)
       :nil
       (do
         (def next-t @{})
-        (put t k (if std-table? next-t @[next-t]))
+        (put t k next-t)
         (set t next-t))
       :array
       (set t (array/peek v))

--- a/test/examples/array-of-tables.toml
+++ b/test/examples/array-of-tables.toml
@@ -1,0 +1,34 @@
+[[products]]
+name = "Hammer"
+sku = 738594937
+
+[[products]]  # empty table within the array
+
+[[products]]
+name = "Nail"
+sku = 284758393
+
+color = "gray"
+
+[[fruits]]
+name = "apple"
+
+[fruits.physical]  # subtable
+color = "red"
+shape = "round"
+
+[[fruits.varieties]]  # nested array of tables
+name = "red delicious"
+
+[[fruits.varieties]]
+name = "granny smith"
+
+
+[[fruits]]
+name = "banana"
+
+[[fruits.varieties]]
+name = "plantain"
+
+[[x.y.z]]
+foo = true

--- a/test/tomlin.janet
+++ b/test/tomlin.janet
@@ -97,4 +97,20 @@
   (is (== expect actual)))
 
 
+(deftest array-of-tables
+  (def expect
+    {:fruits [{:name "apple"
+               :physical {:color "red" :shape "round"}
+               :varieties [{:name "red delicious"}
+                           {:name "granny smith"}]}
+              {:name "banana"
+               :varieties [{:name "plantain"}]}]
+     :products [{:name "Hammer" :sku (int/s64 738594937)}
+                {}
+                {:color "gray" :name "Nail" :sku (int/s64 284758393)}]
+     :x {:y {:z [{:foo true}]}}})
+  (def actual (example "array-of-tables"))
+  (is (== expect actual)))
+
+
 (run-tests!)


### PR DESCRIPTION
As point out in #2, only the last key in an array of tables should cause an array to be added. Otherwise, the keys should cause tables to be added.

This fixes #2.